### PR TITLE
Minor improvements.

### DIFF
--- a/go/bin/compare/compare.go
+++ b/go/bin/compare/compare.go
@@ -28,7 +28,7 @@ import (
 func main() {
 	pathA := flag.String("path_a", "", "Path to ffmpeg-decodable file with signal A.")
 	pathB := flag.String("path_b", "", "Path to ffmpeg-decodable file with signal B.")
-	frequencyResolution := flag.Float64("frequency_resolution", 8.0, "Band width of smallest filter, i.e. expected frequency resolution of human hearing.")
+	frequencyResolution := flag.Float64("frequency_resolution", 5.0, "Band width of smallest filter, i.e. expected frequency resolution of human hearing.")
 	flag.Parse()
 
 	if *pathA == "" || *pathB == "" {

--- a/go/bin/coresvnet/coresvnet.go
+++ b/go/bin/coresvnet/coresvnet.go
@@ -109,12 +109,10 @@ func populate(dest string, workers int) error {
 	if err := pool.Error(); err != nil {
 		return err
 	}
-	for _, ref := range references {
-		if err := study.Put(ref); err != nil {
-			return err
-		}
+	if err := study.Put(references); err != nil {
+		return err
 	}
-	fmt.Println()
+	bar.Finish()
 	return nil
 }
 


### PR DESCRIPTION
- Changed default frequency resolution from 8 to 5, which seems to perform better in general.
- Made Study.Put add all a slice of references in the same transaction, which improves performance a lot when using remote drives.
- Made  print all references in the dataset in a single JSON array instead of individual JSON dictionaries to simplify ingestion via JSON.
- Made progress bar use regular average instead of EMA the first 10 seconds.
- Made progress bar use fractional speed instead of completed-units-speed when predicting ETA, since that automatically takes changing number of pending tasks into account.
- Made progress bar able to finish with an actual time of completion.