### PR TITLE
Added histogram analysis of JND datasets.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,6 @@
 name: Test Zimtohrli
 
 on:
-  push:
   pull_request:
 
 jobs:


### PR DESCRIPTION
Example output when analyzing the https://github.com/pranaymanocha/PerceptualAudio/blob/master/dataset/README.md dataset:

```
*** Evaluations with audible distortions and Zimtohrli distance greater than X
5.00   79    (0.03)  #                                             
10.00  103   (0.04)  #                                             
20.00  223   (0.08)  ####                                          
40.00  1226  (0.45)  ######################                        
80.00  2465  (0.90)  ############################################  

*** Evaluations with non-audible distortions and Zimtohrli distance less than X
5.00   1871  (0.64)  ################################  
10.00  1697  (0.58)  #############################     
20.00  1373  (0.47)  #######################           
40.00  386   (0.13)  ######                            
80.00  41    (0.01)                                    
```