### PR TITLE
Added support for metrics hosted by stdin/stdin-communicating persistent processes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ Finally, to build and test the Python and Go wrappers, the following dependencie
 - python3
 - xxd
 - zlib1g-dev
+- ffmpeg
 
 To install these in a Debian-like system:
 
 ```
-sudo apt install -y cmake ninja-build clang clang-tidy libogg-dev libvorbis-dev libflac-dev libopus-dev libasound2-dev libglfw3-dev golang-go python3 xxd zlib1g-dev
+sudo apt install -y cmake ninja-build clang clang-tidy libogg-dev libvorbis-dev libflac-dev libopus-dev libasound2-dev libglfw3-dev golang-go python3 xxd zlib1g-dev ffmpeg
 ```
 
 Once they are installed, configure the project:

--- a/cpp/zimt/resample.h
+++ b/cpp/zimt/resample.h
@@ -26,7 +26,7 @@
 namespace zimtohrli {
 
 template <typename O, typename I>
-std::vector<O> Convert(absl::Span<I> input) {
+std::vector<O> Convert(absl::Span<const I> input) {
   if constexpr (std::is_same<O, I>::value) {
     std::vector<O> result(input.size());
     memcpy(result.data(), input.data(), input.size() * sizeof(I));
@@ -40,7 +40,7 @@ std::vector<O> Convert(absl::Span<I> input) {
 }
 
 template <typename O, typename I>
-std::vector<O> Resample(absl::Span<I> samples, float in_sample_rate,
+std::vector<O> Resample(absl::Span<const I> samples, float in_sample_rate,
                         float out_sample_rate) {
   if (in_sample_rate == out_sample_rate) {
     return Convert<O>(samples);
@@ -57,8 +57,8 @@ std::vector<O> Resample(absl::Span<I> samples, float in_sample_rate,
       .src_ratio = out_sample_rate / in_sample_rate,
   };
   CHECK_EQ(src_simple(&resample_data, SRC_SINC_BEST_QUALITY, 1), 0);
-  return Convert<O>(
-      absl::Span<float>(result_as_floats.data(), result_as_floats.size()));
+  return Convert<O>(absl::Span<const float>(result_as_floats.data(),
+                                            result_as_floats.size()));
 }
 
 }  // namespace zimtohrli

--- a/cpp/zimt/zimtohrli.cc
+++ b/cpp/zimt/zimtohrli.cc
@@ -425,13 +425,15 @@ Comparison Zimtohrli::Compare(
           current_analysis_a.energy_channels_db.shape()[0];
       for (const auto& dtw_block_pair :
            current_analysis_dtw.energy_channels_db) {
-        const std::pair<size_t, size_t> offset_pair = {
-            dtw_block_pair.first * dtw_block_size,
-            dtw_block_pair.second * dtw_block_size};
+        const size_t first_dtw_offset = dtw_block_pair.first * dtw_block_size;
+        float* audio_delta_data =
+            audio_delta[{audio_channel_index}].data() + first_dtw_offset;
+        const float* frames_a_data =
+            frames_a[{audio_channel_index}].data() + first_dtw_offset;
+        const float* frames_b_data = frames_b[{audio_channel_index}].data() +
+                                     dtw_block_pair.second * dtw_block_size;
         for (size_t index = 0; index < dtw_block_size; ++index) {
-          audio_delta[{audio_channel_index}][offset_pair.first + index] =
-              frames_a[{audio_channel_index}][offset_pair.first + index] -
-              frames_b[{audio_channel_index}][offset_pair.second + index];
+          audio_delta_data[index] = frames_a_data[index] - frames_b_data[index];
         }
       }
 

--- a/go/goohrli/goohrli.h
+++ b/go/goohrli/goohrli.h
@@ -27,14 +27,14 @@
 extern "C" {
 #endif
 
-// void* representation of zimtohrli::Zimtohrli.
-typedef void* Zimtohrli;
-
 // Returns the default frequency resolution.
 float DefaultFrequencyResolution();
 
 // Returns the default perceptual sample rate.
 float DefaultPerceptualSampleRate();
+
+// void* representation of zimtohrli::Zimtohrli.
+typedef void* Zimtohrli;
 
 // Returns a zimtohrli::Zimtohrli for the given parameters.
 Zimtohrli CreateZimtohrli(float sample_rate, float frequency_resolution);

--- a/go/pipe/metric.go
+++ b/go/pipe/metric.go
@@ -1,0 +1,187 @@
+// Copyright 2024 The Zimtohrli Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pipe manages services communicating via pipes.
+package pipe
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/google/zimtohrli/go/aio"
+	"github.com/google/zimtohrli/go/audio"
+	"github.com/google/zimtohrli/go/data"
+	"github.com/google/zimtohrli/go/resource"
+)
+
+// MeterPool contains a resource pool of pipe-communicating processes.
+type MeterPool struct {
+	*resource.Pool[*Metric]
+
+	ScoreType data.ScoreType
+}
+
+// NewMeterPool returns a new pool of pipe-communicating processes.
+func NewMeterPool(path string) (*MeterPool, error) {
+	result := &MeterPool{
+		Pool: &resource.Pool[*Metric]{
+			Create: func() (*Metric, error) { return StartMetric(path) },
+		},
+	}
+	metric, err := result.Get()
+	if err != nil {
+		return nil, err
+	}
+	defer result.Pool.Return(metric)
+	result.ScoreType, err = metric.ScoreType()
+	return result, err
+}
+
+// Close closes all the processes in the pool.
+func (m *MeterPool) Close() error {
+	return m.Pool.Close()
+}
+
+// Measure returns the distance between ref and dist using a metric in the pool, and then returns it to the pool.
+func (m *MeterPool) Measure(ref, dist *audio.Audio) (float64, error) {
+	metric, err := m.Pool.Get()
+	if err != nil {
+		return 0, err
+	}
+	result, err := metric.Measure(ref, dist)
+	if err != nil {
+		return 0, err
+	}
+	m.Pool.Return(metric)
+	return result, nil
+}
+
+// Metric wraps a pipe-communicating process.
+type Metric struct {
+	scoreType data.ScoreType
+	stdin     io.WriteCloser
+	stdout    *bufio.Reader
+	stderr    *bytes.Buffer
+	nextLine  string
+}
+
+// StartMetric starts a new pipe-communicating process.
+func StartMetric(path string) (*Metric, error) {
+	cmd := exec.Command(path)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating stdin pipe for %v: %v", cmd, err)
+	}
+	stderr := &bytes.Buffer{}
+	cmd.Stderr = stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("creating stdout pipe for %v: %v", cmd, err)
+	}
+	m := &Metric{
+		stdin:  stdin,
+		stderr: stderr,
+		stdout: bufio.NewReader(stdout),
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("running %v: %v\n%s", cmd, err, stderr)
+	}
+	return m, nil
+}
+
+func (m *Metric) awaitReady() error {
+	if m.scoreType != "" {
+		return nil
+	}
+	var err error
+	for ; err == nil && !strings.HasPrefix(m.nextLine, "READY:"); m.nextLine, err = m.stdout.ReadString('\n') {
+	}
+	if err != nil {
+		return fmt.Errorf("waiting for READY: %v\n%s", err, m.stderr)
+	}
+	scoreType, found := strings.CutPrefix(strings.TrimSpace(m.nextLine), "READY:")
+	if !found {
+		return fmt.Errorf("%q doesn't have the prefix 'READY:'", m.nextLine)
+	}
+	m.scoreType = data.ScoreType(scoreType)
+	return nil
+}
+
+// ScoreType waits for the process to emit it's score type and returns it.
+func (m *Metric) ScoreType() (data.ScoreType, error) {
+	if err := m.awaitReady(); err != nil {
+		return "", err
+	}
+	return m.scoreType, nil
+}
+
+func (m *Metric) await(msg string) error {
+	var err error
+	for ; err == nil && strings.TrimSpace(m.nextLine) != msg; m.nextLine, err = m.stdout.ReadString('\n') {
+	}
+	if err != nil {
+		return fmt.Errorf("waiting for %q: %v\n%s", msg, err, m.stderr)
+	}
+	return nil
+}
+
+// Measure waits until the process has emitted it's score type (which signals that it's ready) and returns the score for the provided ref and dist.
+func (m *Metric) Measure(ref, dist *audio.Audio) (float64, error) {
+	if err := m.awaitReady(); err != nil {
+		return 0, err
+	}
+	refPath, err := aio.DumpWAV(ref)
+	if err != nil {
+		return 0, fmt.Errorf("dumping referenc audio: %v", err)
+	}
+	defer os.RemoveAll(refPath)
+	distPath, err := aio.DumpWAV(dist)
+	if err != nil {
+		return 0, fmt.Errorf("dumping distortion audio: %v", err)
+	}
+	defer os.RemoveAll(distPath)
+	if err := m.await("REF"); err != nil {
+		return 0, err
+	}
+	if _, err := fmt.Fprintln(m.stdin, refPath); err != nil {
+		return 0, fmt.Errorf("printing ref path: %v\n%s", err, m.stderr)
+	}
+	if err := m.await("DIST"); err != nil {
+		return 0, err
+	}
+	if _, err := fmt.Fprintln(m.stdin, distPath); err != nil {
+		return 0, fmt.Errorf("printing dist path: %v\n%s", err, m.stderr)
+	}
+	for ; err == nil && !strings.HasPrefix(m.nextLine, "SCORE="); m.nextLine, err = m.stdout.ReadString('\n') {
+	}
+	if err != nil {
+		return 0, fmt.Errorf("waiting for SCORE=: %v\n%s", err, m.stderr)
+	}
+	scoreString, found := strings.CutPrefix(strings.TrimSpace(m.nextLine), "SCORE=")
+	if !found {
+		return 0, fmt.Errorf("%q doesn't have the prefix SCORE=", m.nextLine)
+	}
+	return strconv.ParseFloat(scoreString, 64)
+}
+
+// Close closes the process by closing it's stdin.
+func (m *Metric) Close() error {
+	return m.stdin.Close()
+}

--- a/go/resource/pool.go
+++ b/go/resource/pool.go
@@ -1,0 +1,77 @@
+// Copyright 2024 The Zimtohrli Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resource contains tools to handle resource pools.
+package resource
+
+import (
+	"sync"
+
+	"github.com/google/zimtohrli/go/worker"
+)
+
+// Closer can close.
+type Closer interface {
+	Close() error
+}
+
+// Pool produces, keeps tracks of, and releases resources.
+type Pool[T Closer] struct {
+	Create func() (T, error)
+
+	lock      sync.Mutex
+	sequence  int
+	resources map[int]T
+}
+
+// Get returns a resource, which might create a new one.
+func (p *Pool[T]) Get() (T, error) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.resources == nil {
+		p.resources = map[int]T{}
+	}
+	for id, res := range p.resources {
+		delete(p.resources, id)
+		return res, nil
+	}
+	return p.Create()
+}
+
+// Return returns a resource to the pool.
+func (p *Pool[T]) Return(t T) {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	if p.resources == nil {
+		p.resources = map[int]T{}
+	}
+	p.sequence++
+	p.resources[p.sequence] = t
+}
+
+// Close releases all the resources of the pool.
+func (p *Pool[T]) Close() error {
+	p.lock.Lock()
+	defer p.lock.Unlock()
+	errs := worker.Errors{}
+	for _, res := range p.resources {
+		if err := res.Close(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) > 0 {
+		return errs
+	}
+	return nil
+}

--- a/go/worker/pool.go
+++ b/go/worker/pool.go
@@ -18,6 +18,7 @@ package worker
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"sync"
 	"sync/atomic"
 )
@@ -29,6 +30,7 @@ type ChangeHandler func(submitted, completed, errors int)
 type Pool[T any] struct {
 	Workers  int
 	OnChange ChangeHandler
+	FailFast bool
 
 	startOnce sync.Once
 
@@ -59,6 +61,9 @@ func (p *Pool[T]) init() {
 							p.resultsWaitGroup.Done()
 						}()
 					}); err != nil {
+						if p.FailFast {
+							log.Fatal(err)
+						}
 						p.errorsWaitGroup.Add(1)
 						go func() {
 							p.errors <- err

--- a/install_python_metrics.sh
+++ b/install_python_metrics.sh
@@ -1,0 +1,241 @@
+#!/bin/sh
+
+# Copyright 2024 The Ringli Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DST="${1}"
+
+if test -z "${DST}"; then
+    echo "Usage: ${0} DESTINATION_DIRECTORY"
+    exit 1
+fi
+
+INSTALL_LOG="${DST}/install_log.txt"
+
+export PYENV_DST="${DST}/pyenv"
+if test -d "${PYENV_DST}"; then
+    echo "pyenv v2.3.36 already checkout out in ${PYENV_DST}."
+else
+    echo "Checking out pyenv v2.3.36 into ${PYENV_DST}/..."
+    git -c advice.detachedHead=false clone --quiet --branch v2.3.36 --single-branch https://github.com/pyenv/pyenv.git "${PYENV_DST}"
+fi
+
+function install_python() {
+    NAME="${1}"
+    VERSION="${2}"
+    VARNAME="${3}"
+
+    export PYENV_ROOT="${PYENV_DST}/installs/${NAME}"
+    local PYTHON_ROOT="${PYENV_ROOT}/versions/${VERSION}"
+    if test -d "${PYTHON_ROOT}"; then
+        echo "Python ${VERSION} already installed in ${PYTHON_ROOT}."
+    else
+        echo "Installing Python ${VERSION} into ${PYTHON_ROOT}..."
+        "${PYENV_DST}/bin/pyenv" install "${VERSION}" 2> "${INSTALL_LOG}"
+        if test "${?}" != "0"; then
+            cat "${INSTALL_LOG}"
+            exit 2
+        fi
+    fi
+    export "${VARNAME}"="${PYTHON_ROOT}/bin/python"
+}
+
+RETRUNC_PY="${DST}/retrunc.py"
+echo "Dropping library ${RETRUNC_PY}..."
+cat > "${RETRUNC_PY}" << EOF
+import contextlib
+import numpy as np
+import scipy.io.wavfile
+import tempfile
+import sys
+
+def raise_if_nan(samples):
+    if np.any(np.isnan(samples)):
+        raise ValueError(f'nan values in {samples.shape}')
+
+@contextlib.contextmanager
+def resampled_and_truncated_to(path, want_rate = None, want_samples = None):
+    rate, samples = scipy.io.wavfile.read(path)
+    raise_if_nan(samples)
+    if (want_samples and len(samples) != want_samples) or (want_rate and rate != want_rate):
+        if want_rate and rate != want_rate:
+            samples = scipy.signal.resample(samples, int(len(samples) * want_rate / rate))
+            raise_if_nan(samples)
+        if want_samples and len(samples) != want_samples:
+            if want_samples and len(samples) < want_samples:
+                raise ValueError(f'{path} is {samples}s long at rate {want_rate}, which is less than {want_samples}s')
+            if want_samples and len(samples) > want_samples:
+                samples = samples[:want_samples]
+                raise_if_nan(samples)
+        with tempfile.NamedTemporaryFile(suffix='.wav') as f:
+            scipy.io.wavfile.write(f, want_rate, samples)
+            yield f.name
+    else:
+        yield path
+
+@contextlib.contextmanager
+def resample_and_truncate_all(want_rate = None, want_samples = None, untreated_paths = [], treated_paths: list = []):
+    if not untreated_paths:
+        yield treated_paths
+        return
+    last_untreated = untreated_paths.pop()
+    with resampled_and_truncated_to(path=last_untreated, want_rate=want_rate, want_samples=want_samples) as first_treated:
+        treated_paths.insert(0, first_treated)
+        with resample_and_truncate_all(want_rate=want_rate, want_samples=want_samples, untreated_paths=untreated_paths, treated_paths=treated_paths) as treated_paths:
+            yield treated_paths
+
+@contextlib.contextmanager
+def uniform(paths: list):
+    min_seconds = None
+    max_rate = None
+    for path in paths:
+        rate, samples = scipy.io.wavfile.read(path)
+        if not max_rate or rate > max_rate:
+            max_rate = rate
+        seconds = len(samples) / rate
+        if not min_seconds or seconds < min_seconds:
+            min_seconds = seconds
+    want_samples = int(min_seconds * max_rate)
+    with resample_and_truncate_all(want_rate=max_rate, want_samples=want_samples, untreated_paths=paths) as uniform_paths:
+        yield uniform_paths
+EOF
+
+function install_warp_q() {
+    local WARP_Q_ROOT="${DST}/WARP-Q"
+    if test -d "${WARP_Q_ROOT}"; then
+        echo "WARP-Q v1.0.0 already checkout in ${WARP_Q_ROOT}."
+    else
+        echo "Checking out WARP-Q v1.0.0 into ${WARP_Q_ROOT}..."
+        git -c advice.detachedHead=false clone --quiet --branch v1.0.0 --single-branch https://github.com/wjassim/WARP-Q.git "${WARP_Q_ROOT}"
+    fi
+
+    install_python warpq 3.9.18 PYTHON39
+
+    echo "Ensuring WARP-Q dependencies installed..."
+    "${PYTHON39}" -m pip install -r "${WARP_Q_ROOT}/requirements.txt" > "${INSTALL_LOG}" 2>&1
+    if test "${?}" != "0"; then
+        cat "${INSTALL_LOG}"
+        exit 3
+    fi
+
+    local WARP_Q_SCRIPT="${DST}/serve_warp_q.py"
+    echo "Dropping executable ${WARP_Q_SCRIPT}..."
+cat > "${WARP_Q_SCRIPT}" <<EOF
+#!${PYTHON39}
+
+import sys
+import retrunc
+
+sys.path.insert(0,'${WARP_Q_ROOT}')
+from WARPQ.WARPQmetric import warpqMetric
+
+want_samplerate = 16000
+
+args = dict(
+    sr=want_samplerate,
+    mode='predict_file',
+    mapping_model='${WARP_Q_ROOT}/models/SequentialStack/Genspeech_TCDVoIP_PSup23.zip',
+    apply_vad=True,
+    n_mfcc=13,
+    fmax=5000,
+    patch_size=0.4,
+    sigma=[[1,0],[0,3],[1,3]],
+)
+
+warpq = warpqMetric(args)
+print('READY:WARP-Q')
+try:
+    while True:
+        ref = input('REF\n')
+        dist = input('DIST\n')
+        with retrunc.resample_and_truncate_all(want_rate=want_samplerate, untreated_paths=[ref, dist]) as treated_paths:
+            _, warpq_mappedScore = warpq.evaluate(treated_paths[0], treated_paths[1])
+            print(f'SCORE={warpq_mappedScore}')
+except EOFError:
+    pass
+EOF
+    chmod +x "${WARP_Q_SCRIPT}"
+}
+
+install_warp_q
+
+function install_dpam() {
+    install_python dpam 3.7.17 PYTHON37
+
+    echo "Installing DPAM and dependencies..."
+    "${PYTHON37}" -m pip install -U dpam==0.0.4 numba==0.48.0 protobuf==3.20.3 tensorflow==1.14.0 scikit-learn==0.20.3 scipy==1.2.1 tqdm==4.32.2 resampy==0.2.2 librosa==0.7.2 > "${INSTALL_LOG}" 2>&1
+    if test "${?}" != "0"; then
+        cat "${INSTALL_LOG}"
+        exit 3
+    fi
+
+    local DPAM_SCRIPT="${DST}/serve_dpam.py"
+    echo "Dropping executable ${DPAM_SCRIPT}..."
+cat > "${DPAM_SCRIPT}" <<EOF
+#!${PYTHON37}
+
+import dpam
+import retrunc
+
+loss_fn = dpam.DPAM()
+print('READY:DPAM')
+try:
+    while True:
+        ref = input('REF\n')
+        dist = input('DIST\n')
+        with retrunc.uniform([ref, dist]) as uniform_paths:
+            ref_wav = dpam.load_audio(uniform_paths[0])
+            dist_wav = dpam.load_audio(uniform_paths[1])
+            print(f'SCORE={loss_fn.forward(ref_wav, dist_wav)[0]}')
+except EOFError:
+    pass
+EOF
+    chmod +x "${DPAM_SCRIPT}"
+}
+
+install_dpam
+
+function install_cdpam() {
+    install_python cdpam 3.7.17 PYTHON37
+
+    echo "Installing CDPAM and dependencies..."
+    "${PYTHON37}" -m pip install cdpam==0.0.6 torch==1.4.0 numba==0.48.0 librosa==0.7.2 matplotlib==2.2.5 numpy==1.16.6 resampy==0.2.2 scikit-learn==0.20.4 scipy==1.2.3 tqdm==4.43.0 tensorboard==2.1.0 future > "${INSTALL_LOG}" 2>&1
+    if test "${?}" != "0"; then
+        cat "${INSTALL_LOG}"
+        exit 3
+    fi
+
+    local CDPAM_SCRIPT="${DST}/serve_cdpam.py"
+    echo "Dropping executable ${CDPAM_SCRIPT}..."
+cat > "${CDPAM_SCRIPT}" <<EOF
+#!${PYTHON37}
+
+import cdpam
+
+loss_fn = cdpam.CDPAM(dev='cpu')
+print('READY:CDPAM')
+try:
+    while True:
+        ref = input('REF\n')
+        dist = input('DIST\n')
+        ref_wav = cdpam.load_audio(ref)
+        dist_wav = cdpam.load_audio(dist)
+        print(f'SCORE={loss_fn.forward(ref_wav, dist_wav)[0]}')
+except EOFError:
+    pass
+EOF
+    chmod +x "${CDPAM_SCRIPT}"
+}
+
+install_cdpam


### PR DESCRIPTION
- Added a resource pool that can reuse expensive to create resources.
- Added a metric that uses stdin/stdout of a child process to measure acoustic distances.
- Added a metric that proxies a pool of stdin/stdin-metrics.
- Updated the dependencies in the README.
- Made the resample functions more const.
- Made the zimtohrli audio delta comparison slightly easier to read.
- Added saving functionality to the audio I/O package.
- Added support for the stdin/stdout metric in the compare tool.
- Made the compare tool able to compute multiple metrics in one run.
- Made the compare tool print what metric it's printing.
- Made the worker pool able to fail fast on the first job error.
- Added a fail-fast option to the score tool.
- Made the score tool default to _no_ metrics, and error out if none are provided.
- Added support for the stdin/stdout metric in the score tool.
- Added bash script that installs WARP-Q, DPAM, and CDPAM along with wrappers that makes them conform to the stdin/stdout metric specs.