### PR TITLE
less memory traffic, 3x speedup for tabuli

### DIFF
--- a/cpp/zimt/compare.cc
+++ b/cpp/zimt/compare.cc
@@ -300,8 +300,6 @@ int Main(int argc, char* argv[]) {
     const size_t num_downscaled_samples_a = static_cast<size_t>(
         std::ceil(static_cast<float>(file_a->Frames().shape()[1]) *
                   z.perceptual_sample_rate / z.cam_filterbank->sample_rate));
-    hwy::AlignedNDArray<float, 2> channels_a(
-        {file_a->Frames().shape()[1], z.cam_filterbank->filter.Size()});
     hwy::AlignedNDArray<float, 2> energy_channels_db_a(
         {num_downscaled_samples_a, z.cam_filterbank->filter.Size()});
     hwy::AlignedNDArray<float, 2> partial_energy_channels_db_a(
@@ -311,7 +309,7 @@ int Main(int argc, char* argv[]) {
          ++channel_index) {
       hwy::AlignedNDArray<float, 2> spectrogram(
           {num_downscaled_samples_a, z.cam_filterbank->filter.Size()});
-      z.Spectrogram(file_a->Frames()[{channel_index}], channels_a,
+      z.Spectrogram(file_a->Frames()[{channel_index}],
                     energy_channels_db_a, partial_energy_channels_db_a,
                     spectrogram);
       file_a_spectrograms.push_back(std::move(spectrogram));
@@ -322,8 +320,6 @@ int Main(int argc, char* argv[]) {
       const size_t num_downscaled_samples_b = static_cast<size_t>(
           std::ceil(static_cast<float>(file_b.Frames().shape()[1]) *
                     z.perceptual_sample_rate / z.cam_filterbank->sample_rate));
-      hwy::AlignedNDArray<float, 2> channels_b(
-          {file_b.Frames().shape()[1], z.cam_filterbank->filter.Size()});
       hwy::AlignedNDArray<float, 2> energy_channels_db_b(
           {num_downscaled_samples_b, z.cam_filterbank->filter.Size()});
       hwy::AlignedNDArray<float, 2> partial_energy_channels_db_b(
@@ -333,7 +329,7 @@ int Main(int argc, char* argv[]) {
       float sum_of_squares = 0;
       for (size_t channel_index = 0; channel_index < file_a->Info().channels;
            ++channel_index) {
-        z.Spectrogram(file_b.Frames()[{channel_index}], channels_b,
+        z.Spectrogram(file_b.Frames()[{channel_index}],
                       energy_channels_db_b, partial_energy_channels_db_b,
                       spectrogram_b);
         const float distance =

--- a/cpp/zimt/fourier_bank.h
+++ b/cpp/zimt/fourier_bank.h
@@ -24,14 +24,6 @@ constexpr int64_t kNumRotators = 128;
 
 float GetRotatorGains(int i);
 
-enum FilterMode {
-  IDENTITY,
-  AMPLITUDE,
-  PHASE,
-};
-
-float BarkFreq(float v);
-
 struct PerChannel {
   // [0..1] is for real and imag of 1st leaking accumulation
   // [2..3] is for real and imag of 2nd leaking accumulation
@@ -53,19 +45,17 @@ struct Rotators {
   float window[kNumRotators];
   float gain[kNumRotators];
 
-  int FindMedian3xLeaker(float window);
-
   Rotators() = default;
   Rotators(int num_channels, std::vector<float> frequency,
            std::vector<float> filter_gains, const float sample_rate,
            float global_gain);
 
-  void Filter(hwy::Span<const float> signal,
-              hwy::AlignedNDArray<float, 2>& channels);
+  void FilterAndDownsample(hwy::Span<const float> signal,
+                           hwy::AlignedNDArray<float, 2>& channels,
+                           int downsample);
 
   void OccasionallyRenormalize();
   void IncrementAll(float signal);
-  float GetSample(int c, int i, FilterMode mode = IDENTITY) const;
   std::vector<float> rotator_frequency;
 };
 

--- a/cpp/zimt/goohrli.cc
+++ b/cpp/zimt/goohrli.cc
@@ -103,9 +103,7 @@ Analysis Analyze(Zimtohrli zimtohrli, float* data, int size) {
   zimtohrli::Zimtohrli* z = static_cast<zimtohrli::Zimtohrli*>(zimtohrli);
   hwy::AlignedNDArray<float, 1> signal({static_cast<size_t>(size)});
   hwy::CopyBytes(data, signal.data(), size * sizeof(float));
-  hwy::AlignedNDArray<float, 2> channels(
-      {signal.shape()[0], tabuli::kNumRotators});
-  zimtohrli::Analysis analysis = z->Analyze(signal[{}], channels);
+  zimtohrli::Analysis analysis = z->Analyze(signal[{}]);
   return new zimtohrli::Analysis{
       .energy_channels_db = std::move(analysis.energy_channels_db),
       .partial_energy_channels_db =

--- a/cpp/zimt/masking.h
+++ b/cpp/zimt/masking.h
@@ -19,22 +19,6 @@
 
 namespace zimtohrli {
 
-// Populates the energy_channels with the (possibly downsampled) energy of the
-// sample_channels.
-//
-// Input and output contains linear energy values.
-//
-// sample_channels is a (num_samples, num_channels)-shaped array with samples.
-//
-// energy_channels is a (downscaled_num_samples, num_channels)-shaped array with
-// energy (mean square of samples).
-//
-// num_downscaled_samples must be less than num_samples, and is typically 100
-// x duration of the sound for a perceptual intensity sample rate of 100Hz
-// which has proven reasonable for human hearing time resolution.
-void ComputeEnergy(const hwy::AlignedNDArray<float, 2>& sample_channels,
-                   hwy::AlignedNDArray<float, 2>& energy_channels);
-
 // Populates energy_channels_db with the dB energy value of
 // energy_channels_linear.
 //

--- a/cpp/zimt/masking_test.cc
+++ b/cpp/zimt/masking_test.cc
@@ -31,50 +31,6 @@ void CheckNear(hwy::Span<float> span, std::vector<float> expected) {
               testing::Pointwise(testing::FloatNear(1e-5), expected));
 }
 
-TEST(Masking, ComputeEnergyTest) {
-  hwy::AlignedNDArray<float, 2> sample_channels({10, 2});
-  for (size_t sample_index = 0; sample_index < sample_channels.shape()[0];
-       ++sample_index) {
-    sample_channels[{sample_index}] = {
-        static_cast<float>(sample_index + 1),
-        static_cast<float>((sample_index + 1) * 2)};
-  }
-  hwy::AlignedNDArray<float, 2> got_energy_downsampled_2x({5, 2});
-  ComputeEnergy(sample_channels, got_energy_downsampled_2x);
-  CheckNear(got_energy_downsampled_2x[{0}],
-            {(1.0 + 4.0) / 2.0, (4.0 + 16.0) / 2.0});
-  CheckNear(got_energy_downsampled_2x[{1}],
-            {(9.0 + 16.0) / 2.0, (36.0 + 64.0) / 2.0});
-  CheckNear(got_energy_downsampled_2x[{2}],
-            {(25.0 + 36.0) / 2.0, (100.0 + 144.0) / 2.0});
-  CheckNear(got_energy_downsampled_2x[{3}],
-            {(49.0 + 64.0) / 2.0, (14.0 * 14.0 + 16.0 * 16.0) / 2.0});
-  CheckNear(got_energy_downsampled_2x[{4}],
-            {(81.0 + 100.0) / 2.0, (18.0 * 18.0 + 400.0) / 2.0});
-
-  hwy::AlignedNDArray<float, 2> got_energy_downsampled_5x({2, 2});
-  ComputeEnergy(sample_channels, got_energy_downsampled_5x);
-  CheckNear(got_energy_downsampled_5x[{0}],
-            {(1.0 + 4.0 + 9.0 + 16.0 + 25.0) / 5.0,
-             (4.0 + 16.0 + 36.0 + 64.0 + 100.0) / 5.0});
-  CheckNear(got_energy_downsampled_5x[{1}],
-            {(36.0 + 49.0 + 64.0 + 81.0 + 100.0) / 5.0,
-             (144.0 + 14.0 * 14.0 + 16.0 * 16.0 + 18.0 * 18.0 + 400.0) / 5.0});
-}
-
-void BM_ComputeEnergy(benchmark::State& state) {
-  const size_t sample_rate = 48000;
-  const hwy::AlignedNDArray<float, 2> sample_channels(
-      {sample_rate * state.range(0), 1024});
-  hwy::AlignedNDArray<float, 2> energy_channels(
-      {100 * static_cast<size_t>(state.range(0)), 1024});
-  for (auto s : state) {
-    ComputeEnergy(sample_channels, energy_channels);
-  }
-  state.SetItemsProcessed(sample_channels.size() * state.iterations());
-}
-BENCHMARK_RANGE(BM_ComputeEnergy, 1, 64);
-
 TEST(Masking, ToDbToLinear) {
   hwy::AlignedNDArray<float, 2> energy_channels_linear({2, 2});
   energy_channels_linear[{0}] = {0.1, 0.01};

--- a/cpp/zimt/pyohrli.cc
+++ b/cpp/zimt/pyohrli.cc
@@ -124,10 +124,8 @@ std::optional<zimtohrli::Analysis> Analyze(
   }
   hwy::AlignedNDArray<float, 1> signal_array({buffer_view.len / sizeof(float)});
   hwy::CopyBytes(buffer_view.buf, signal_array.data(), buffer_view.len);
-  hwy::AlignedNDArray<float, 2> channels(
-      {signal_array.size(), zimtohrli.cam_filterbank->filter.Size()});
   return std::optional<zimtohrli::Analysis>{
-      zimtohrli.Analyze(signal_array[{}], channels)};
+      zimtohrli.Analyze(signal_array[{}])};
 }
 
 PyObject* BadArgument(const std::string& message) {

--- a/cpp/zimt/zimtohrli.h
+++ b/cpp/zimt/zimtohrli.h
@@ -214,14 +214,12 @@ struct Zimtohrli {
   // case it will be populated with the spectrogram content after the function
   // returns.
   void Spectrogram(hwy::Span<const float> signal, FilterbankState& state,
-                   hwy::AlignedNDArray<float, 2>& channels,
                    hwy::AlignedNDArray<float, 2>& energy_channels_db,
                    hwy::AlignedNDArray<float, 2>& partial_energy_channels_db,
                    hwy::AlignedNDArray<float, 2>& spectrogram) const;
 
   // Spectrogram without chunk processing.
   void Spectrogram(hwy::Span<const float> signal,
-                   hwy::AlignedNDArray<float, 2>& channels,
                    hwy::AlignedNDArray<float, 2>& energy_channels_db,
                    hwy::AlignedNDArray<float, 2>& partial_energy_channels_db,
                    hwy::AlignedNDArray<float, 2>& spectrogram) const;
@@ -252,12 +250,10 @@ struct Zimtohrli {
   //
   // channels is a (num_samples, num_channels)-shaped array that will be
   // populated with the audio samples in the individual channels.
-  Analysis Analyze(hwy::Span<const float> signal, FilterbankState& state,
-                   hwy::AlignedNDArray<float, 2>& channels) const;
+  Analysis Analyze(hwy::Span<const float> signal, FilterbankState& state) const;
 
   // Analyze without chunk processing.
-  Analysis Analyze(hwy::Span<const float> signal,
-                   hwy::AlignedNDArray<float, 2>& channels) const;
+  Analysis Analyze(hwy::Span<const float> signal) const;
 
   // Convenience method to compare multi channel audios.
   //


### PR DESCRIPTION
|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.101162755033022 |0.563709113431054 |0.773872237318597 |0.691086927997167 |
|ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
|2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
|PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
|CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
|PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
|AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
|PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
|DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
|WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
|GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |


real	3m37.704s
user	184m0.443s
sys	42m52.675s
