### PR TITLE
Added a streaming spectrogram function

### DIFF
--- a/cpp/zimt/pyohrli.py
+++ b/cpp/zimt/pyohrli.py
@@ -24,12 +24,6 @@ def mos_from_zimtohrli(zimtohrli_distance: float) -> float:
     return _pyohrli.MOSFromZimtohrli(zimtohrli_distance)
 
 
-class Analysis:
-    """Wrapper around C++ zimtohrli::Analysis."""
-
-    _cc_analysis: _pyohrli.Analysis
-
-
 class Pyohrli:
     """Wrapper around C++ zimtohrli::Zimtohrli."""
 
@@ -44,44 +38,6 @@ class Pyohrli:
             the expected frequency resolution of human hearing at low frequencies.
         """
         self._cc_pyohrli = _pyohrli.Pyohrli(sample_rate)
-
-    def analyze(self, signal: npt.ArrayLike) -> Analysis:
-        """Analyzes a signal.
-
-        Args:
-          signal: The signal to analyze. A (num_samples,)-shaped array of floats
-            between -1 and 1. The expected playout intensity in dB SPL of a 1kHz
-            sine wave between -1 and 1 is defined by setting 'full_scale_sine_db' of
-            this Pyohrli instance.
-
-        Returns:
-          An Analysis instance containing a psychoacoustic analysis of the signal.
-        """
-        result = Analysis()
-        # Disabling protected-access to avoid making Analysis._cc_pyohrli public.
-        result._cc_analysis = (
-            self._cc_pyohrli.analyze(  # pylint: disable=protected-access
-                np.asarray(signal).astype(np.float32).ravel().data,
-            )
-        )
-        return result
-
-    def analysis_distance(self, analysis_a: Analysis, analysis_b: Analysis) -> float:
-        """Computes the distance between two psychoacoustic analyses.
-
-        Args:
-          analysis_a: An Analysis instance to compare.
-          analysis_b: Another Analysis instance to compare with.
-
-        Returns:
-          The Zimtohrli distance between the two analyses.
-        """
-        return self._cc_pyohrli.analysis_distance(
-            # Disabling protected-access to avoid making Analysis._cc_pyohrli
-            # public.
-            analysis_a._cc_analysis,  # pylint: disable=protected-access
-            analysis_b._cc_analysis,  # pylint: disable=protected-access
-        )
 
     def distance(self, signal_a: npt.ArrayLike, signal_b: npt.ArrayLike) -> float:
         """Computes the distance between two signals.

--- a/cpp/zimt/pyohrli_test.py
+++ b/cpp/zimt/pyohrli_test.py
@@ -55,11 +55,7 @@ class PyohrliTest(unittest.TestCase):
         sample_rate = 48000.0
         metric = pyohrli.Pyohrli(sample_rate)
         signal_a = np.sin(np.linspace(0.0, np.pi * 2 * a_hz, int(sample_rate)))
-        analysis_a = metric.analyze(signal_a)
         signal_b = np.sin(np.linspace(0.0, np.pi * 2 * b_hz, int(sample_rate)))
-        analysis_b = metric.analyze(signal_b)
-        analysis_distance = metric.analysis_distance(analysis_a, analysis_b)
-        self.assertLess(abs(analysis_distance - distance), 1e-3)
         distance = metric.distance(signal_a, signal_b)
         self.assertLess(abs(distance - distance), 1e-3)
 
@@ -69,7 +65,7 @@ class PyohrliTest(unittest.TestCase):
         signal = np.sin(np.linspace(0.0, np.pi * 2 * 440.0, int(sample_rate)))
         # This would crash the program if pyohrli.cc didn't limit the upper
         # threshold to half the sample rate.
-        metric.analyze(signal)
+        metric.distance(signal, signal)
 
     @parameterize(
         dict(zimtohrli_distance=0.0, mos=5.0),

--- a/cpp/zimt/zimtohrli.h
+++ b/cpp/zimt/zimtohrli.h
@@ -219,12 +219,26 @@ struct Zimtohrli {
                    hwy::AlignedNDArray<float, 2>& partial_energy_channels_db,
                    hwy::AlignedNDArray<float, 2>& spectrogram) const;
 
-  // Spectrogram without chunk processing.
+  // Spectrogram defaulting to a fresh filter bank state.
   void Spectrogram(hwy::Span<const float> signal,
                    hwy::AlignedNDArray<float, 2>& channels,
                    hwy::AlignedNDArray<float, 2>& energy_channels_db,
                    hwy::AlignedNDArray<float, 2>& partial_energy_channels_db,
                    hwy::AlignedNDArray<float, 2>& spectrogram) const;
+
+  // Memory thrifty spectrogram calculation that computes one chunk (samples per
+  // perceptual sample rate period) at a time.
+  //
+  // Since it only computes one chunk at a time it only needs a chunk of
+  // channels, energy_channels_db, and partial_energy_channels_db that it
+  // allocates and reuses.
+  //
+  // signal is a span of audio samples between -1 and 1.
+  //
+  // Returns a (num_downscaled_samples, num_channels)-shaped array of Phons
+  // values reprecenting the perceptual intensity of each channel.
+  hwy::AlignedNDArray<float, 2> StreamingSpectrogram(
+      hwy::Span<const float> signal) const;
 
   // Returns the perceptual distance between the two spectrograms.
   //

--- a/go/goohrli/goohrli.go
+++ b/go/goohrli/goohrli.go
@@ -316,34 +316,9 @@ func (g *Goohrli) NormalizedAudioDistance(audioA, audioB *audio.Audio) (float64,
 	return result, nil
 }
 
-// Analysis is a Go wrapper around zimthrli::Analysis.
-type Analysis struct {
-	analysis C.Analysis
-}
-
-// Analyze returns an analysis of the signal.
-func (g *Goohrli) Analyze(signal []float32) *Analysis {
-	result := &Analysis{
-		analysis: C.Analyze(g.zimtohrli, (*C.float)(&signal[0]), C.int(len(signal))),
-	}
-	runtime.SetFinalizer(result, func(a *Analysis) {
-		C.FreeAnalysis(a.analysis)
-	})
-	return result
-}
-
-// AnalysisDistance returns the Zimtohrli distance between two analyses.
-func (g *Goohrli) AnalysisDistance(analysisA *Analysis, analysisB *Analysis) float32 {
-	return float32(C.AnalysisDistance(g.zimtohrli, analysisA.analysis, analysisB.analysis))
-}
-
 // Distance returns the Zimtohrli distance between two signals.
 func (g *Goohrli) Distance(signalA []float32, signalB []float32) float64 {
-	analysisA := C.Analyze(g.zimtohrli, (*C.float)(&signalA[0]), C.int(len(signalA)))
-	defer C.FreeAnalysis(analysisA)
-	analysisB := C.Analyze(g.zimtohrli, (*C.float)(&signalB[0]), C.int(len(signalB)))
-	defer C.FreeAnalysis(analysisB)
-	return float64(C.AnalysisDistance(g.zimtohrli, analysisA, analysisB))
+	return float64(C.Distance(g.zimtohrli, (*C.float)(&signalA[0]), C.int(len(signalA)), (*C.float)(&signalB[0]), C.int(len(signalB))))
 }
 
 // ViSQOL is a Go wrapper around zimtohrli::ViSQOL.

--- a/go/goohrli/goohrli.h
+++ b/go/goohrli/goohrli.h
@@ -76,13 +76,6 @@ Zimtohrli CreateZimtohrli(ZimtohrliParameters params);
 // Deletes a zimtohrli::Zimtohrli.
 void FreeZimtohrli(Zimtohrli z);
 
-// void* representation of zimtohrli::Analysis.
-typedef void* Analysis;
-
-// Returns a zimtohrli::Analysis produced by the provided zimtohrli::Zimtohrli
-// and using the provided perceptual_sample_rate and data.
-Analysis Analyze(Zimtohrli zimtohrli, float* data, int size);
-
 // Plain C version of zimtohrli::EnergyAndMaxAbsAmplitude.
 typedef struct {
   float EnergyDBFS;
@@ -106,12 +99,9 @@ EnergyAndMaxAbsAmplitude NormalizeAmplitude(float max_abs_amplitude,
 // (zimtohrli::Distance(..., perceptual_sample_rate, ...) of 100Hz.
 float MOSFromZimtohrli(float zimtohrli_distance);
 
-// Deletes a zimtohrli::Analysis.
-void FreeAnalysis(Analysis a);
-
-// Returns the Zimtohrli distance between two analyses using the provided
-// zimtohrli::Zimtohrli.
-float AnalysisDistance(Zimtohrli zimtohrli, Analysis a, Analysis b);
+// Returns the Zimtohrli distance between data_b and data_b.
+float Distance(Zimtohrli zimtohrli, float* data_a, int size_a, float* data_b,
+               int size_b);
 
 // Sets the parameters.
 //

--- a/go/goohrli/goohrli_test.go
+++ b/go/goohrli/goohrli_test.go
@@ -124,15 +124,9 @@ func TestGoohrli(t *testing.T) {
 		for index := 0; index < len(soundA); index++ {
 			soundA[index] = float32(math.Sin(2 * math.Pi * tc.freqA * float64(index) / params.SampleRate))
 		}
-		analysisA := g.Analyze(soundA)
 		soundB := make([]float32, int(params.SampleRate))
 		for index := 0; index < len(soundB); index++ {
 			soundB[index] = float32(math.Sin(2 * math.Pi * tc.freqB * float64(index) / params.SampleRate))
-		}
-		analysisB := g.Analyze(soundB)
-		analysisDistance := float64(g.AnalysisDistance(analysisA, analysisB))
-		if d := rdiff(analysisDistance, tc.distance); d > 0.1 {
-			t.Errorf("Distance = %v, want %v", analysisDistance, tc.distance)
 		}
 		distance := float64(g.Distance(soundA, soundB))
 		if d := rdiff(distance, tc.distance); d > 0.1 {


### PR DESCRIPTION
StreamingSpectrogram processes audio one 1/perceptual_sample_rate chunk at a time, and therefore needs much less memory allocated for intermediate data.