### PR TITLE
less memory access by streaming the log10s for dbs

### DIFF
--- a/cpp/zimt/fourier_bank.cc
+++ b/cpp/zimt/fourier_bank.cc
@@ -43,6 +43,11 @@ float GetRotatorGains(int i) {
   return kRotatorGains[i];
 }
 
+float SimpleDb(float energy) {
+  static const float full_scale_sine_db = 78.3;
+  return 10 * log10(channels[{out_ix}][k] + 1e-9) + full_scale_sine_db;
+}
+
 void Rotators::FilterAndDownsample(hwy::Span<const float> signal,
                                    hwy::AlignedNDArray<float, 2>& channels,
                                    int downsampling) {
@@ -55,7 +60,8 @@ void Rotators::FilterAndDownsample(hwy::Span<const float> signal,
       if (input_ix >= signal.size()) {
         if (out_ix < channels.shape()[0]) {
           for (int k = 0; k < kNumRotators; ++k) {
-            channels[{out_ix}][k] *= scaling_for_downsampling;
+            channels[{out_ix}][k] =
+                SimpleDb(scaling_for_downsampling * channels[{out_ix}][k]);
           }
         }
         if (out_ix != channels.shape()[0] - 1) {
@@ -83,7 +89,8 @@ void Rotators::FilterAndDownsample(hwy::Span<const float> signal,
       }
     }
     for (int k = 0; k < kNumRotators; ++k) {
-      channels[{out_ix}][k] *= scaling_for_downsampling;
+      channels[{out_ix}][k] =
+          SimpleDb(scaling_for_downsampling * channels[{out_ix}][k]);
     }
     ++out_ix;
     if (out_ix >= channels.shape()[0]) {

--- a/cpp/zimt/zimtohrli.cc
+++ b/cpp/zimt/zimtohrli.cc
@@ -289,16 +289,10 @@ void Zimtohrli::Spectrogram(
   }
 
   int downsample = signal.size() / energy_channels_db.shape()[0];
-  /* old code from hwycomputeenergy */
-  //  const size_t num_out_samples = energy_channels.shape()[0];
-  // const size_t downscaling = sample_channels.shape()[0] / num_out_samples;
 
-  //  printf("downsample %d\n", downsample);
   tabuli::Rotators rots(1, freqs, gains, cam_filterbank->sample_rate, 1.0f);
   rots.FilterAndDownsample(signal, energy_channels_db, downsample);
 
-  // ComputeEnergy(channels, energy_channels_db);
-  ToDb(energy_channels_db, full_scale_sine_db, epsilon, energy_channels_db);
   if (apply_masking) {
     masking.CutFullyMasked(energy_channels_db, cam_filterbank->cam_delta,
                            partial_energy_channels_db);


### PR DESCRIPTION
|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.101162746942526 |0.563709113431054 |0.773872237318597 |0.691086968125479 |
|ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
|2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
|PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
|CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
|PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
|AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
|PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
|DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
|WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
|GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |

real	3m39.800s
user	186m13.002s
sys	42m43.169s