### PR TITLE
more rotators (128->150) improves MSE by a few %

### DIFF
--- a/cpp/zimt/cam.cc
+++ b/cpp/zimt/cam.cc
@@ -45,7 +45,7 @@ CamFilterbank Cam::CreateFilterbank(float sample_rate) const {
 
   int sections = -1;
   for (float left_cam = low_threshold_cam;
-       left_cam + cam_delta < high_threshold_cam; left_cam += cam_delta) {
+       left_cam + 0.5 * cam_delta < high_threshold_cam; left_cam += cam_delta) {
     float left_hz = HzFromCam(left_cam);
     float right_hz = HzFromCam(left_cam + cam_delta);
     const std::vector<BACoeffs> filter_coeffs = DigitalSOSBandPass(

--- a/cpp/zimt/cam.h
+++ b/cpp/zimt/cam.h
@@ -70,7 +70,7 @@ struct Cam {
   float high_threshold_hz = 20000;
   // Frequency resolution at low threshold. Default is 5 since it has
   // provided the best correlation scores with tested datasets.
-  float minimum_bandwidth_hz = 5;
+  float minimum_bandwidth_hz = 1;
   // Order (sharpness and slowness) of channel filters.
   int filter_order = 1;
   // Attenuation in dB in each filter where the filterbank filters meet.

--- a/cpp/zimt/fourier_bank.cc
+++ b/cpp/zimt/fourier_bank.cc
@@ -19,7 +19,7 @@
 namespace tabuli {
 
 float GetRotatorGains(int i) {
-  static const float kRotatorGains[kNumRotators] = {
+  static const float kRotatorGains[128] = {
       1.050645, 1.948438, 3.050339, 3.967913, 4.818584, 5.303335, 5.560281,
       5.490826, 5.156689, 4.547374, 3.691308, 2.666868, 1.539254, 0.656948,
       0.345893, 0.327111, 0.985318, 1.223506, 0.447645, 0.830961, 1.075181,

--- a/cpp/zimt/fourier_bank.h
+++ b/cpp/zimt/fourier_bank.h
@@ -20,7 +20,7 @@
 
 namespace tabuli {
 
-constexpr int64_t kNumRotators = 128;
+constexpr int64_t kNumRotators = 150;
 
 float GetRotatorGains(int i);
 

--- a/cpp/zimt/zimtohrli.cc
+++ b/cpp/zimt/zimtohrli.cc
@@ -285,6 +285,7 @@ void Zimtohrli::Spectrogram(
   std::vector<float> gains;
   for (size_t i = 0; i < cam_filterbank->filter.Size(); ++i) {
     freqs.push_back(cam_filterbank->thresholds_hz[{1}][i]);
+    //freqs.push_back(20.0 * pow(1000.0, 1.0 * i / (cam_filterbank->filter.Size() - 1)));
     gains.push_back(1.0);
   }
 


### PR DESCRIPTION
|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.098637219950560 |0.567187736693103 |0.777010861372363 |0.694493861132456 |
|ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
|2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
|PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
|CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
|PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
|AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
|PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
|DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
|WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
|GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |

real	4m19.323s
user	222m49.575s
sys	43m16.317s