### PR TITLE
more optimization of heuristics, ~1 % improvement

### DIFF
--- a/cpp/zimt/fourier_bank.cc
+++ b/cpp/zimt/fourier_bank.cc
@@ -18,34 +18,10 @@
 
 namespace tabuli {
 
-float GetRotatorGains(int i) {
-  static const float kRotatorGains[128] = {
-      1.050645, 1.948438, 3.050339, 3.967913, 4.818584, 5.303335, 5.560281,
-      5.490826, 5.156689, 4.547374, 3.691308, 2.666868, 1.539254, 0.656948,
-      0.345893, 0.327111, 0.985318, 1.223506, 0.447645, 0.830961, 1.075181,
-      0.613335, 0.902695, 0.855391, 0.817774, 0.823359, 0.841483, 0.838562,
-      0.831912, 0.808731, 0.865214, 0.808036, 0.850837, 0.821305, 0.839458,
-      0.829195, 0.836373, 0.827271, 0.836018, 0.834514, 0.825624, 0.836999,
-      0.833990, 0.832992, 0.830897, 0.832593, 0.846116, 0.824796, 0.829331,
-      0.844509, 0.838830, 0.821733, 0.840738, 0.841735, 0.827570, 0.838581,
-      0.837742, 0.834965, 0.842970, 0.832145, 0.847596, 0.840942, 0.830891,
-      0.850632, 0.841468, 0.838383, 0.841493, 0.855118, 0.826750, 0.848000,
-      0.874356, 0.812177, 0.849037, 0.893550, 0.832527, 0.827986, 0.877198,
-      0.851760, 0.846317, 0.883044, 0.843178, 0.856925, 0.857045, 0.860695,
-      0.894345, 0.870391, 0.839519, 0.870541, 0.870573, 0.902951, 0.871798,
-      0.818328, 0.871413, 0.921101, 0.863915, 0.793014, 0.936519, 0.888107,
-      0.856968, 0.821018, 0.987345, 0.904846, 0.783447, 0.973613, 0.903628,
-      0.875688, 0.931024, 0.992087, 0.806914, 1.050332, 0.942569, 0.800870,
-      1.210426, 0.916555, 0.817352, 1.126946, 0.985119, 0.922530, 0.994633,
-      0.959602, 0.381419, 1.879201, 2.078451, 0.475196, 0.952731, 1.709305,
-      1.383894, 1.557669,
-  };
-  return kRotatorGains[i];
-}
-
 float SimpleDb(float energy) {
-  static const float full_scale_sine_db = 78.3;
-  return 10 * log10(energy + 1e-9) + full_scale_sine_db;
+  static const float full_scale_sine_db = 78.26561963526045; // 78.3 ideally
+  static const float epsilon = 1.0033294789821357e-09;
+  return 10 * log10(energy + epsilon) + full_scale_sine_db;
 }
 
 void Rotators::FilterAndDownsample(hwy::Span<const float> signal,
@@ -106,21 +82,21 @@ double CalculateBandwidth(double low, double mid, double high) {
 }
 
 Rotators::Rotators(int num_channels, std::vector<float> frequency,
-                   std::vector<float> filter_gains, const float sample_rate,
-                   float global_gain) {
+                   std::vector<float> filter_gains, const float sample_rate) {
   channel.resize(num_channels);
+  static const float kWindow = 0.9996028710680265;
+  static const double kBandwidthMagic = 0.7322402492401391;
   for (int i = 0; i < kNumRotators; ++i) {
     // The parameter relates to the frequency shape overlap and window length
     // of triple leaking integrator.
-    float kWindow = 0.9996;
-    float w40Hz = std::pow(kWindow, 128.0 / kNumRotators);  // at 40 Hz.
     float bw = CalculateBandwidth(
         i == 0 ? frequency[1] : frequency[i - 1], frequency[i],
         i + 1 == kNumRotators ? frequency[i - 1] : frequency[i + 1]);
-    window[i] = std::pow(kWindow, bw * 0.7018);
+    window[i] = std::pow(kWindow, bw * kBandwidthMagic);
     float windowM1 = 1.0f - window[i];
     float f = frequency[i] * 2.0f * M_PI / sample_rate;
-    gain[i] = 2.0 * filter_gains[i] * global_gain * pow(windowM1, 3.0);
+    const float gainer = 2.0f;
+    gain[i] = gainer * filter_gains[i] * pow(windowM1, 3.0);
     rot[0][i] = float(std::cos(f));
     rot[1][i] = float(-std::sin(f));
     rot[2][i] = gain[i];

--- a/cpp/zimt/fourier_bank.h
+++ b/cpp/zimt/fourier_bank.h
@@ -22,8 +22,6 @@ namespace tabuli {
 
 constexpr int64_t kNumRotators = 150;
 
-float GetRotatorGains(int i);
-
 struct PerChannel {
   // [0..1] is for real and imag of 1st leaking accumulation
   // [2..3] is for real and imag of 2nd leaking accumulation
@@ -47,8 +45,7 @@ struct Rotators {
 
   Rotators() = default;
   Rotators(int num_channels, std::vector<float> frequency,
-           std::vector<float> filter_gains, const float sample_rate,
-           float global_gain);
+           std::vector<float> filter_gains, const float sample_rate);
 
   void FilterAndDownsample(hwy::Span<const float> signal,
                            hwy::AlignedNDArray<float, 2>& channels,

--- a/cpp/zimt/zimtohrli.cc
+++ b/cpp/zimt/zimtohrli.cc
@@ -291,7 +291,7 @@ void Zimtohrli::Spectrogram(
 
   int downsample = signal.size() / energy_channels_db.shape()[0];
 
-  tabuli::Rotators rots(1, freqs, gains, cam_filterbank->sample_rate, 1.0f);
+  tabuli::Rotators rots(1, freqs, gains, cam_filterbank->sample_rate);
   rots.FilterAndDownsample(signal, energy_channels_db, downsample);
 
   if (apply_masking) {


### PR DESCRIPTION
|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.097175453861064 |0.581050442393818 |0.776654974298645 |0.696445877155239 |
|ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
|2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
|PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
|CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
|PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
|AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
|PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
|DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
|WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
|GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |