### PR TITLE
~5% worse, but faster and simpler

### DIFF
--- a/cpp/zimt/fourier_bank.h
+++ b/cpp/zimt/fourier_bank.h
@@ -20,7 +20,7 @@
 
 namespace tabuli {
 
-constexpr int64_t kNumRotators = 150;
+constexpr int64_t kNumRotators = 128;
 
 struct PerChannel {
   // [0..1] is for real and imag of 1st leaking accumulation

--- a/cpp/zimt/zimtohrli.h
+++ b/cpp/zimt/zimtohrli.h
@@ -285,10 +285,10 @@ struct Zimtohrli {
   std::optional<CamFilterbank> cam_filterbank;
 
   // The window in perceptual_sample_rate time steps when compting the NSIM.
-  size_t nsim_step_window = 16;
+  size_t nsim_step_window = 8;
 
   // The window in channels when computing the NSIM.
-  size_t nsim_channel_window = 30;
+  size_t nsim_channel_window = 16;
 
   // The window of the dynamic time warp that matches audio signals.
   //


### PR DESCRIPTION
|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.076254461155707 |0.589172424723762 |0.806090520228513 |0.731427610098147 |
|ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
|2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
|PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
|CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
|PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
|AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
|PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
|DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
|WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
|GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |

reducing the gammatone filters from 150 to 128

reducing NSIM size from 32x16 to 16x8 -- 32 bands would be more than 2 octaves of blurring!?!

revamping masking into something simpler, but also not axis separating temporal and frequency masking effects