### PR TITLE
further simplifications

### DIFF
--- a/cpp/zimt/nsim.cc
+++ b/cpp/zimt/nsim.cc
@@ -199,8 +199,9 @@ float HwyNSIM(const hwy::AlignedNDArray<float, 2>& a,
         return Mul(delta_a, delta_b);
       });
   const Vec two = Set(d, 2.0);
-  const Vec C1 = Set(d, 0.19863327786546683);
-  const Vec C3 = Set(d, 0.17538360286546675);
+  const Vec C1 = Set(d, 64.820932997704162);
+  const Vec C3 = Set(d, 11.285860868315538);
+  const Vec C4 = Set(d, 1e-6 * 2.9262932000000021);
   float nsim_sum = 0.0;
   const Vec num_channels_vec = Set(d, num_channels);
   const Vec zero = Zero(d);
@@ -219,8 +220,9 @@ float HwyNSIM(const hwy::AlignedNDArray<float, 2>& a,
       const Vec intensity = Div(
           MulAdd(two, Mul(mean_a_vec, mean_b_vec), C1),
           MulAdd(mean_a_vec, mean_a_vec, MulAdd(mean_b_vec, mean_b_vec, C1)));
-      const Vec structure =
-          Div(Add(cov_vec, C3), MulAdd(std_a_vec, std_b_vec, C3));
+      const Vec structure_base = Div(Add(cov_vec, C3), MulAdd(std_a_vec, std_b_vec, C3));
+      const Vec structure_clamped = IfThenElse(Lt(structure_base, zero), zero, structure_base);
+      const Vec structure = Sqrt(Sqrt(Add(structure_clamped, C4)));
       const Vec channel_index_vec = Iota(d, channel_index);
       const Vec nsim = IfThenElse(Lt(channel_index_vec, num_channels_vec),
                                   Mul(intensity, structure), zero);

--- a/cpp/zimt/zimtohrli.h
+++ b/cpp/zimt/zimtohrli.h
@@ -279,7 +279,7 @@ struct Zimtohrli {
 
   // Sample rate corresponding to the human hearing sensitivity to timing
   // differences.
-  float perceptual_sample_rate = 85.0;
+  float perceptual_sample_rate = 97.969986924466824;
 
   // The filterbank used to separate the signal in frequency channels.
   std::optional<CamFilterbank> cam_filterbank;
@@ -288,7 +288,7 @@ struct Zimtohrli {
   size_t nsim_step_window = 8;
 
   // The window in channels when computing the NSIM.
-  size_t nsim_channel_window = 16;
+  size_t nsim_channel_window = 7;
 
   // The window of the dynamic time warp that matches audio signals.
   //


### PR DESCRIPTION
taking correct frequency buckets from ISO loudness

reducing structural similarity support area

'''
Score type |MSE               |Min score         |Max score         |Mean score        |
-----------|------------------|------------------|------------------|------------------|
Zimtohrli  |0.074958337059633 |0.609170013051075 |0.804501676659602 |0.732603836275400 |
ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |
'''