### PR TITLE
Fix channel mismatch during normalization

### DIFF
--- a/cpp/zimt/compare.cc
+++ b/cpp/zimt/compare.cc
@@ -246,7 +246,7 @@ int Main(int argc, char* argv[]) {
       for (size_t channel_index = 0; channel_index < file_b->Info().channels;
            ++channel_index) {
         const EnergyAndMaxAbsAmplitude new_energy_and_max_abs_amplitude =
-            NormalizeAmplitude(file_a_max_abs_amplitude,
+            NormalizeAmplitude(file_a_measurements[channel_index].max_abs_amplitude,
                                file_b->Frames()[{channel_index}]);
         if (verbose) {
           std::cerr << "  Normalized channel " << channel_index << " energy = "

--- a/cpp/zimt/compare.cc
+++ b/cpp/zimt/compare.cc
@@ -208,13 +208,10 @@ int Main(int argc, char* argv[]) {
     return 4;
   }
   std::vector<EnergyAndMaxAbsAmplitude> file_a_measurements;
-  float file_a_max_abs_amplitude = 0;
   for (size_t channel_index = 0; channel_index < file_a->Info().channels;
        ++channel_index) {
     EnergyAndMaxAbsAmplitude measurements =
         Measure(file_a->Frames()[{channel_index}]);
-    file_a_max_abs_amplitude =
-        std::max(file_a_max_abs_amplitude, measurements.max_abs_amplitude);
     file_a_measurements.push_back(measurements);
   }
   const bool verbose = absl::GetFlag(FLAGS_verbose);


### PR DESCRIPTION
Previously, all channels in file b were normalized to the second channel in file a, instead of the correct, corresponding channel. This commit fixes that.