### PR TITLE
restoring basic filter balance from prev version

### DIFF
--- a/cpp/zimt/fourier_bank.cc
+++ b/cpp/zimt/fourier_bank.cc
@@ -394,8 +394,8 @@ Rotators::Rotators(int num_channels, std::vector<float> frequency,
 		   int downsample) {
   const float scaling_for_downsampling = 1.0f / downsample;
   channel.resize(num_channels);
-  static const double kWindow = 0.99971274067289151;
-  static const double kBandwidthMagic = 0.73283668663046908;
+  static const double kWindow = 0.9996028710680265;
+  static const double kBandwidthMagic = 0.7328516996032982;
   for (int i = 0; i < kNumRotators; ++i) {
     // The bw parameter relates to the frequency shape overlap and window length
     // of the triple leaking integrator (3rd-order complex gammatone filter).


### PR DESCRIPTION
~2.5 % improvement

```
|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.081764574149153 |0.556914901149026 |0.836478875724214 |0.723880965157041 |
|ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
|2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
|PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
|CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
|PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
|AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
|PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
|DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
|WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
|GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |
```