### PR TITLE
adjusting a strange normalizing factor

### DIFF
--- a/cpp/zimt/fourier_bank.cc
+++ b/cpp/zimt/fourier_bank.cc
@@ -149,7 +149,7 @@ float Loudness(int k, float val) {
     0.58639078360761954,
     0.37335527143387232,
   };
-  static const float off = exp(80) * 1e-10;
+  static const float off = 1e16 * 1e-10;
   return log(val + off) * kMul[k];
 }
 
@@ -537,7 +537,7 @@ Rotators::Rotators(int downsample) {
     window[i] = std::pow(kWindow, bw * kBandwidthMagic);
     float windowM1 = 1.0f - window[i];
     float f = Frequency(i) * 2.0f * M_PI / kSampleRate;
-    static const float full_scale_sine_db = exp(80);
+    static const float full_scale_sine_db = 1e16;
     static const float scale_normalizer = 0.00019;
     const float gainer = sqrt(scaling_for_downsampling * full_scale_sine_db * scale_normalizer * Frequency(i));
     gain[i] = gainer * pow(windowM1, 3.0);


### PR DESCRIPTION
improves MSE by 2 %

```
|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.079785215152953 |0.576702702767793 |0.829250952631593 |0.725835507015320 |
|ViSQOL     |0.115330916105424 |0.520833375452983 |0.801480831107469 |0.675101633981268 |
|2f         |0.129541391104905 |0.484687555319526 |0.797475783883375 |0.661870345773127 |
|PESQ       |0.147425552045669 |0.342342966279351 |0.841271127756762 |0.647128996775172 |
|CDPAM      |0.153471222942756 |0.441558428344727 |0.728779141125759 |0.620699318941738 |
|PARLAQ     |0.185057687192323 |0.445261140223642 |0.784370761057963 |0.587162756572532 |
|AQUA       |0.223207996944378 |0.331645933512413 |0.739286336419790 |0.547804951221731 |
|PEAQB      |0.225217321572038 |0.278744167467764 |0.851011116004117 |0.553935720513487 |
|DPAM       |0.315810440183130 |0.186717781679534 |0.690564701717118 |0.460415212267967 |
|WARP-Q     |0.339686211572685 |0.067600137543649 |0.777119464646524 |0.475793617709890 |
|GVPMOS     |0.412937133868407 |0.006851162794410 |0.783946603687895 |0.412912222208318 |
```

and min score a bit more

ideally this normalizing factor shouldn't have a lot of impact, it is unclear where the impact comes from