### PR TITLE
Moved Span outside the anonymous namespace.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(zimtohrli_visqol_adapter STATIC
     cpp/zimt/visqol.h
     cpp/zimt/visqol.cc
     cpp/zimt/resample.h
+    cpp/zimt/zimtohrli.h
 )
 target_include_directories(zimtohrli_visqol_adapter PUBLIC cpp)
 target_link_libraries(zimtohrli_visqol_adapter PRIVATE visqol samplerate)

--- a/cpp/zimt/zimtohrli.h
+++ b/cpp/zimt/zimtohrli.h
@@ -24,6 +24,29 @@
 
 namespace zimtohrli {
 
+template <typename T>
+struct Span {
+  Span(const Span& other) = default;
+  Span(std::vector<T>& vec) : size(vec.size()), data(vec.data()) {}
+  explicit Span(T* data, size_t size) : size(size), data(data) {}
+  template <typename U>
+  Span(const std::vector<U>& vec) noexcept
+      : data(vec.data()), size(vec.size()) {
+    static_assert(std::is_convertible_v<U(*)[], T(*)[]>,
+                  "Cannot construct Span from vector of incompatible type.");
+  }
+  template <typename U>
+  Span(const Span<U>& other) noexcept : data(other.data), size(other.size) {
+    static_assert(std::is_convertible_v<U(*)[], T(*)[]>,
+                  "Cannot construct Span from Span of incompatible type.");
+  }
+  Span& operator=(const Span& other) = default;
+  const T& operator[](size_t index) const { return data[index]; }
+  T& operator[](size_t index) { return data[index]; }
+  size_t size;
+  T* data;
+};
+
 namespace {
 
 constexpr int64_t kNumRotators = 128;
@@ -221,29 +244,6 @@ class Rotators {
       }
     }
   }
-};
-
-template <typename T>
-struct Span {
-  Span(const Span& other) = default;
-  Span(std::vector<T>& vec) : size(vec.size()), data(vec.data()) {}
-  explicit Span(T* data, size_t size) : size(size), data(data) {}
-  template <typename U>
-  Span(const std::vector<U>& vec) noexcept
-      : data(vec.data()), size(vec.size()) {
-    static_assert(std::is_convertible_v<U(*)[], T(*)[]>,
-                  "Cannot construct Span from vector of incompatible type.");
-  }
-  template <typename U>
-  Span(const Span<U>& other) noexcept : data(other.data), size(other.size) {
-    static_assert(std::is_convertible_v<U(*)[], T(*)[]>,
-                  "Cannot construct Span from Span of incompatible type.");
-  }
-  Span& operator=(const Span& other) = default;
-  const T& operator[](size_t index) const { return data[index]; }
-  T& operator[](size_t index) { return data[index]; }
-  size_t size;
-  T* data;
 };
 
 // A simple buffer of float samples describing a spectrogram with a given number


### PR DESCRIPTION
Since its used by other libraries outside the header-only zimtohrli.h it needs to be accessible outside anonymous namespace it seems.