### PR TITLE
Don't use -ffast-math since code uses infinity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_CLANG_TIDY clang-tidy)
 add_compile_options(-fPIC)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native -O3 -ffast-math")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -O3 -ffast-math")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=native -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native -O3")
 
 include(cmake/deps.cmake)
 

--- a/cpp/zimt/fourier_bank_test.cc
+++ b/cpp/zimt/fourier_bank_test.cc
@@ -232,7 +232,7 @@ TEST(FourierBank, GoldenNumbers) {
   };
   for (size_t chan = 0; chan < kNumRotators / 10; chan++) {
     for (size_t i = 0; i < 48; i++) {
-      assert(spec[{chan * kNumRotators / 10}][i] == want_spec[chan][i]);
+      assert(spectrogram[{chan * kNumRotators / 10}][i] == want_spec[chan][i]);
     }
   }
 }


### PR DESCRIPTION
Combining the two is UB and appears to cause a crash when built with Clang.

Drive-by: fix debug build.