### PR TITLE
improved normalization

### DIFF
--- a/tools/optimizer/random_fork.py
+++ b/tools/optimizer/random_fork.py
@@ -101,7 +101,7 @@ def Eval(vec, binary_name, cached=True):
   #corpus = 'odaq'
   print("popen")
   process = subprocess.Popen(
-      ('/usr/lib/google-golang/bin/go', 'run', '../go/bin/score/score.go', '--force',
+      ('/usr/bin/go', 'run', '../go/bin/score/score.go', '--force',
        '--calculate_zimtohrli',
        '--calculate', '/usr/local/google/home/jyrki/' + g_sample + '/' + corpus,
        '--leaderboard', '/usr/local/google/home/jyrki/' + g_sample + '/' + corpus,


### PR DESCRIPTION
improved normalization with some heuristics adjustements that were made possible by improved normalization

past numbers in https://github.com/google/zimtohrli/pull/180

This PR gives 1.1--3.5 % better MSE in the MOS >= 2.9

all corpora, all mos

|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.068939332162233 |0.548262817776116 |0.860380914824380 |0.752878572654707 |
|ViSQOL     |0.111404873626568 |0.520833375452983 |0.801480831107469 |0.680010591098095 |

real    5m21.025s
user    221m28.353s
sys     45m58.791s

all corpora, mos >= 2.9

|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.092899804720907 |0.488097103559078 |0.883921472570817 |0.722056665806971 |
|ViSQOL     |0.132590049828861 |0.442272696472662 |0.862948574554870 |0.668233000093051 |

odaq, all mos

|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.035778245495289 |0.810848617516845 |0.810848617516845 |0.810848617516845 |
|ViSQOL     |0.076070491316864 |0.724191205149539 |0.724191205149539 |0.724191205149539 |

odaq, mos >= 2.9

|Score type |MSE               |Min score         |Max score         |Mean score        |
|-----------|------------------|------------------|------------------|------------------|
|Zimtohrli  |0.052193011318118 |0.771542101650833 |0.771542101650833 |0.771542101650833 |
|ViSQOL     |0.167732011747987 |0.590449012029043 |0.590449012029043 |0.590449012029043 |