### PR TITLE
Remove variable name prefix more aggressively

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ set_target_properties(zimtohrli_pyohrli PROPERTIES
    OUTPUT_NAME _pyohrli.so
    SUFFIX ""
 )
-target_link_libraries(zimtohrli_pyohrli Python3::Python absl::check)
+target_link_libraries(zimtohrli_pyohrli Python3::Python)
 
 add_library(zimtohrli_goohrli_glue STATIC
     cpp/zimt/goohrli.cc

--- a/cmake/visqol.cmake
+++ b/cmake/visqol.cmake
@@ -23,7 +23,7 @@ target_include_directories(visqol_proto PUBLIC ${visqol_PROTO_DIR})
 set(visqol_MODEL_H ${visqol_SOURCE_DIR}/src/include/libsvm_nu_svr_model.h)
 add_custom_command(
     OUTPUT ${visqol_MODEL_H}
-	COMMAND sh -c "xxd -i ${visqol_SOURCE_DIR}/model/libsvm_nu_svr_model.txt | sed 's/[A-Za-z_]*libsvm_nu_svr_model_txt/visqol_model_bytes/' > ${visqol_MODEL_H}"
+	COMMAND sh -c "xxd -i ${visqol_SOURCE_DIR}/model/libsvm_nu_svr_model.txt | sed 's/[^ ]*libsvm_nu_svr_model_txt/visqol_model_bytes/' > ${visqol_MODEL_H}"
     DEPENDS ${visqol_SOURCE_DIR}/model/libsvm_nu_svr_model.txt
 	VERBATIM
 ) 


### PR DESCRIPTION
Directory names containing e.g. digits could cause too little of the path to be stripped.